### PR TITLE
Update SSM prefix for application version

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -98,7 +98,7 @@ locals {
     cross_account_role    = local.shared_config.role_arns.set_version
     ecr_image_tag_filters = ["master-branch"]
     ecr_repo_name_filters = [local.name_prefix]
-    ssm_prefix            = local.name_prefix
+    ssm_prefix            = local.shared_config.name_prefix
   }
 
   service_input_set_version = jsonencode(local.common_input_set_version)


### PR DESCRIPTION
The _Bump Versions in ..._ step is currently saving the newest application version to an SSM parameter `/trafficinfo-baseline-micronaut/trafficinfo-baseline-micronaut`, while the application infrastructure in `terraform/template/main.tf` references an SSM parameter `/trafficinfo/trafficinfo-baseline-micronaut`.

This means that baseline-micronaut is currently running on an old version.

This PR updates the _Bump Versions in ..._ state to save the application version to `/trafficinfo/trafficinfo-baseline-micronaut` instead.