### PR TITLE
Add slack orb to circleci config and update README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,19 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+commands:
+  install-slack-status-prerequisites:
+    steps:
+      - run:
+          name: "Add slack notifier prerequisites"
+          command: |
+            apk add bash
+            apk add curl
+  invoke-slack-status:
+    steps:
+      - slack/status:
+          failure_message: A $CIRCLE_JOB job failed for project << pipeline.project.git_url >> ($CIRCLE_BRANCH)
+          fail_only: true
 jobs:
   validate-terraform:
     docker:
@@ -159,20 +174,40 @@ jobs:
             fi
             printf "Uploading trigger event file to s3://%s/%s\n" "$s3_bucket" "$s3_prefix"
             aws s3 cp ./*.json "s3://${s3_bucket}/${s3_prefix}/"
+  slack-workflow-status:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - slack/notify:
+          color: '#1CBF43'
+          message: Success:workflow in job $CIRCLE_BUILD_URL for project << pipeline.project.git_url >> ($CIRCLE_BRANCH)
+          include_visit_job_action: false
 workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - validate-terraform
+      - validate-terraform:
+          pre-steps:
+            - install-slack-status-prerequisites
+          post-steps:
+            - invoke-slack-status
       - build-source:
           context: trafficinfo
+          post-steps:
+            - invoke-slack-status
       - build-docker:
-            requires:
+          requires:
             - build-source
+          pre-steps:
+            - install-slack-status-prerequisites
+          post-steps:
+            - invoke-slack-status
       - build-repo-zip:
           filters:
             branches:
               only: master
+          post-steps:
+            - invoke-slack-status
       - upload-repo-zip:
           filters:
             branches:
@@ -181,9 +216,29 @@ workflows:
             - build-repo-zip
             - build-docker
             - validate-terraform
+          pre-steps:
+            - install-slack-status-prerequisites
+          post-steps:
+            - invoke-slack-status
       - upload-trigger-event:
           filters:
             branches:
               only: master
           requires:
             - upload-repo-zip
+          pre-steps:
+            - install-slack-status-prerequisites
+          post-steps:
+            - invoke-slack-status
+      - slack-workflow-status:
+          filters:
+            branches:
+              only: master
+          requires:
+            - upload-trigger-event
+      - slack-workflow-status:
+          filters:
+            branches:
+              ignore: master
+          requires:
+            - build-docker

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See https://jico.nsb.no/confluence/display/TRAFFICINFO/Baseline+Micronaut
 3. Set up an ECR for the microservice
 Create a new module based on ecr-baseline-micronaut in trafficinfo-aws/terraform/circleci-init/main.tf.
 Add the new ecr-repository to the module "ci_machine_user", and update the number of allowed ecr_count. 
+Add a state machine for this project to the state_machine_arns list in the locals section.
 
 4. CircleCI setup
 CircleCI is responsible for running tests, and building the artifacts before publishing it to ECR to be deployed to ECS.
@@ -49,15 +50,13 @@ AWS_SECRET_ACCESS_KEY
     The AWS variables can be found in the AWS Systems Manager -> Parameter Store. AWS_ACCESS_KEY_ID can be found in ci-machine-user-id, and the 
     AWS_SECRET_ACCESS_KEY can be found under ci-machine-user-key.
  
-    1. Generate a "status badge" in Circle CI that can be used in README.md for the new microservice. If the project is private (default) you'll need to create
-an access token first. This is currently only available in the old UI. 
+    1. Exchange the "status badge" at the top of the readme by editing the following with the correct values for this project:
+    \[\!\[CircleCI\](https://circleci.com/gh/nsbno/<PROJECT_NAME>.svg?style=svg&circle-token=<YOUR_STATUS_API_TOKEN>)\](https://circleci.com/gh/nsbno/<PROJECT_NAME>)
+        * PROJECT_NAME is the name of the github project
+        * YOUR_STATUS_API_TOKEN is found in the circle-ci project settings. Go to "API Permissions" and create an API token with the scope "status".
 
-    2. In CircleCI, Add the slack webhook-url to Circle CI for build notifications. This is currently only available in the old UI.
+    2. In CircleCI, Add the slack webhook-url to Circle CI for build notifications by going to project settings and "Slack Integration"
 
-5. Establish OpenAPI schema by copying "empty.yml" (if a REST API is supposed to be exposed by the service)
+5. Update with correct project naming in all the terraform/\<ENVIRONMENT>/main.tf files.
 
-6. Create application config in terraform/modules/application-config. Create files variables.tf, main.tf and output.tf
-
-7. Create ECS module by copying one of the existing modules, e.g. svc-otc.yml and create a config containing at least application config and 
-an ecs-microservice module. Remove all redundant config. NOTE: Remember to choose a unique ALB priority for the module. 
 


### PR DESCRIPTION
Virker ikke lenger som det gamle UIet til CircleCI er tilgjengelig. Oppdaterer README med beskrivelse som passer til det nye.

Har i tillegg satt opp slack orb i circle ci configen. I det nye UI har ikke circleci tenkt å støtte den slack integrasjonen som vi har brukt tidligere, og man må bruke slack orb istedet. https://circleci.com/orbs/registry/orb/circleci/slack

Oppdaterte også README med relevant info for ny individuell state-machine.