### PR TITLE
Make slack notification and gradle build great again.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  stepfunction-ci: vydev/ciorb@dev:update-docker-images
+  stepfunction-ci: vydev/ciorb@dev:1.0.1
 
   # TODO
   # Move this code into our own ORB


### PR DESCRIPTION
prøvde meg på å trekke ut funksjonaliteten for slack og gradle bygg til eksterne, konfigurerbare funksjoner i bygget slik at vi kan flytte det ut til egen orb senere.

Tanken er å teste at alt funker og så publisere koden som en ORB for trafficinfo.