### PR TITLE
Remove explicit version of micronaut-aws-parameter-store

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     implementation("io.micronaut:micronaut-tracing")
     implementation("io.micronaut.security:micronaut-security")
     implementation("io.micronaut.security:micronaut-security-jwt")
-    implementation("io.micronaut.aws:micronaut-aws-parameter-store:2.2.4")
+    implementation("io.micronaut.aws:micronaut-aws-parameter-store")
     implementation("io.micronaut.cache:micronaut-cache-caffeine")
 
     kapt(platform("io.micronaut:micronaut-bom:$micronautVersion"))


### PR DESCRIPTION
Fjerner eksplisitt versjon, fordi denne hentes automatisk fra micronaut-bom