### PR TITLE
Remove explicit versions in build.gradle.kts and use versions from micronaut-bom instead

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-discovery-client")
     implementation("io.micronaut.aws:micronaut-aws-common")
-    implementation("io.micronaut.configuration:micronaut-micrometer-registry-cloudwatch:1.3.1")
+    implementation("io.micronaut.micrometer:micronaut-micrometer-registry-cloudwatch")
     implementation("io.micronaut:micronaut-tracing")
     implementation("io.micronaut.security:micronaut-security")
     implementation("io.micronaut.security:micronaut-security-jwt")
@@ -99,8 +99,8 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-ssm:1.11.946")
     implementation("no.cantara.aws:sqs-util:0.7.6")
     implementation("io.swagger.core.v3:swagger-annotations")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1")
-    implementation("ch.qos.logback:logback-classic:1.2.3")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("ch.qos.logback:logback-classic")
 
     /**
      * Test dependency configurations.
@@ -108,10 +108,10 @@ dependencies {
     testAnnotationProcessor("io.micronaut:micronaut-inject-java")
     testImplementation(platform("io.micronaut:micronaut-bom:$micronautVersion"))
     testImplementation("io.micronaut.test:micronaut-test-junit5")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    testImplementation("org.assertj:assertj-core:3.19.0")
+    testImplementation("org.assertj:assertj-core")
     testImplementation("com.github.tomakehurst:wiremock:2.27.2")
     testImplementation("io.mockk:mockk:1.10.5")
 


### PR DESCRIPTION
Micronaut-bom som vi drar inn inneholder versjonering av en hel del forskjellige dependenciesvi bruker. Foreslår at vi der det er mulig fjerner våres eksplisitte satte versjoner og heller benytter oss av micronaut-bom. Da vil vi havne litt bakpå på versjoner, men så lenge vi oppgraderer micronaut ofte så blir det ikke så gale. Og vi slipper ganske mange av renovate PRene, som uansett blir liggende såpass lenge at vi havner bakpå der og.

Det er nok enda flere versjoner som kan fjernes rundt omkring i andre prosjekter, f.eks. postgres og testcontainers kommer og inn via micronaut-bom. Men disse er da ikke i bruk her i baselinen