### PR TITLE
Set version for pipeline managed environments to 0.13.6

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,6 +1,6 @@
 # TODO replace all <placeholders>
 terraform {
-  required_version = "=0.14.7"
+  required_version = ">=0.13.6"
 
   backend "s3" {
     key            = "trafficinfo-baseline-micronaut/main.tfstate"

--- a/terraform/prod/versions.tf
+++ b/terraform/prod/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.8"
     }
   }
-  required_version = "= 0.14.7"
+  required_version = ">= 0.13.6"
 }

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -139,7 +139,7 @@ locals {
   }))
   test_input_single_use_fargate_task = jsonencode(merge(local.common_input_single_use_fargate_task, {
     task_role_arn = local.shared_config.role_arns.single_use_fargate_task_task
-    image         = "vydev/terraform:0.14.7"
+    image         = "vydev/terraform:0.13.6"
     cmd_to_run = format(lookup(local.string_templates_single_use_fargate_task, "cmd_to_run", ""),
       local.shared_config.role_arns.deploy_test,
       "cd terraform/test && terraform init -lock-timeout=120s && terraform apply -auto-approve -lock-timeout=120s"
@@ -147,7 +147,7 @@ locals {
   }))
   stage_input_single_use_fargate_task = jsonencode(merge(local.common_input_single_use_fargate_task, {
     task_role_arn = local.shared_config.role_arns.single_use_fargate_task_task
-    image         = "vydev/terraform:0.14.7"
+    image         = "vydev/terraform:0.13.6"
     cmd_to_run = format(lookup(local.string_templates_single_use_fargate_task, "cmd_to_run", ""),
       local.shared_config.role_arns.deploy_stage,
       "cd terraform/stage && terraform init -lock-timeout=120s && terraform apply -auto-approve -lock-timeout=120s"
@@ -155,7 +155,7 @@ locals {
   }))
   prod_input_single_use_fargate_task = jsonencode(merge(local.common_input_single_use_fargate_task, {
     task_role_arn = local.shared_config.role_arns.single_use_fargate_task_task
-    image         = "vydev/terraform:0.14.7"
+    image         = "vydev/terraform:0.13.6"
     cmd_to_run = format(lookup(local.string_templates_single_use_fargate_task, "cmd_to_run", ""),
       local.shared_config.role_arns.deploy_prod,
       "cd terraform/prod && terraform init -lock-timeout=120s && terraform apply -auto-approve -lock-timeout=120s"

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -1,6 +1,6 @@
 # TODO replace all <placeholders>
 terraform {
-  required_version = "=0.14.7"
+  required_version = ">=0.13.6"
 
   backend "s3" {
     key            = "trafficinfo-baseline-micronaut/main.tfstate"

--- a/terraform/stage/versions.tf
+++ b/terraform/stage/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.8"
     }
   }
-  required_version = "= 0.14.7"
+  required_version = ">= 0.13.6"
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -1,6 +1,6 @@
 # TODO replace all <placeholders>
 terraform {
-  required_version = "=0.14.7"
+  required_version = ">=0.13.6"
 
   backend "s3" {
     key            = "trafficinfo-baseline-micronaut/main.tfstate"

--- a/terraform/test/versions.tf
+++ b/terraform/test/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.8"
     }
   }
-  required_version = "= 0.14.7"
+  required_version = ">= 0.13.6"
 }


### PR DESCRIPTION
Viser seg at selv om det ikke kreves endringer i koden mellom 0.13 og 0.14 så får man feilmelding om man kjører apply med versjon 0.14.x på en state laget med 0.12.x, må derfor innom 0.13 og få en apply der først.

Oppgraderer videre til 0.14.7 etter denne er blitt applyet en gang