### PR TITLE
TRAFFICINFO-487 bump common logging for better defaults.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     /**
      * Trafficinfo Common Dependencies.
      */
-    implementation("no.vy.trafficinfo.common:logging:0.0.2")
+    implementation("no.vy.trafficinfo.common:logging:0.0.3")
     implementation("no.vy.trafficinfo.common:security:0.1.2")
 
     /**

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="no/vy/trafficinfo/common/logging/base.xml"/>
-
 </configuration>
-

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%cyan(%d{yyyy-MM-dd HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="no.vy" level="DEBUG" />
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
better defaults for logging, will log INFO messages from no.vy packages, and WARN from other.