### PR TITLE
Properly disable basic-auth in configuration

### DIFF
--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -8,10 +8,8 @@ micronaut:
   # and contain the url to the public endpoint where public keys are published
   # to verify signatures in JWT token.
   security:
-    enabled: true
-    token:
-      basic-auth:
-        enabled: false
+    basic-auth:
+      enabled: false
 
   http:
     services:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,9 +35,6 @@ micronaut:
               url: ${jwksUrl}
             trafficinfoCognito:
               url: ${trafficinfoJwksUrl}
-      writer:
-        header:
-          enabled: true
       propagation:
         # propagate only to known services
         # the access token should be treated like normal credentials and not must not be


### PR DESCRIPTION
# Description

Disabling basic-auth, and removing MN 1.x header propagation configuration

# Changelog

- Disabled basic-auth properly
- Removed Micronaut 1.x header propagation configuration
