### PR TITLE
Fix trigger pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ workflows:
             - ruteplan
           requires:
             - build-and-push-image
-
-#          filters:
-#            branches:
-#              only: [ master ]
+          filters:
+            branches:
+              only: [ master ]


### PR DESCRIPTION
# Description

Configure `trigger-pipeline` when terraform and deployment config is in external repository, like in baseline
- trafficinfo-baseline-micronaut is the service
- trafficinfo-baseline-terraform is the infrastructure and pipeline.

# Changelog

- Describe added features
- Describe changed features
- Describe deleted features
